### PR TITLE
Use separate read-only and read-write connections & handle HUP signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ login data in MusicBrainz.
 
 Please make sure that your bot does not violate the
 [Code of Conduct](https://musicbrainz.org/doc/Code_of_Conduct/Bots) for bots in MusicBrainz
+
+The configuration of a running bot can be reloaded by sending it a HUP signal.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,14 @@ the latter with
 > python2 setup.py install
 
 Copy `bot/settings.py.dist` to `bot/settings.py` and edit the connection string
-which is documented
+settings. Their format is
+documented
 [here](http://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING).
+
+The `readonly_connection_string` is used to connect to a MusicBrainz database to
+extract all the entities that have links to Wikipedia articles. The `readwrite`
+connection string is used to connect to a database with read and write access to
+keep a log of all already processed MBIDs.
 
 If you want the bot to automatically edit URLs to redirect pages in Wikipedia to
 their target pages, do

--- a/bot/common.py
+++ b/bot/common.py
@@ -5,7 +5,6 @@ psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODEARRAY)
 import pywikibot as wp
 import signal
-import sys
 
 
 from . import const, settings

--- a/bot/common.py
+++ b/bot/common.py
@@ -20,6 +20,7 @@ from urlparse import urlparse
 
 # Set up a signal handler to reload the settings on SIGHUP
 def signal_handler(signal, frame):
+    wp.output("HUP received")
     reload(settings)
     setup_db()
 

--- a/bot/common.py
+++ b/bot/common.py
@@ -278,7 +278,8 @@ def mainloop():
         wiki_entity_query = create_url_mbid_query(entitytype, linkids)
         all_results = do_readonly_query(wiki_entity_query, limit)
         already_processed_query = create_already_processed_query(entitytype)
-        already_processed_results = do_readwrite_query(already_processed_query)
+        already_processed_results = frozenset(
+            do_readwrite_query(already_processed_query))
 
         results_to_process = [r for r in all_results if r[0] not in
                               already_processed_results]

--- a/bot/common.py
+++ b/bot/common.py
@@ -270,7 +270,7 @@ def entity_type_loop(bot, entitytype, limit):
     results_to_process = [r for r in all_results if r[0] not in
                           already_processed_results]
 
-    if all_results.rowcount == 0:
+    if len(results_to_process) == 0:
         wp.output("No more unprocessed entries in MB")
 
     map(bot.process_result, results_to_process)

--- a/bot/common.py
+++ b/bot/common.py
@@ -19,6 +19,7 @@ WIKI_PREFIX = "/wiki/"
 
 
 readonly_db = None
+readwrite_db = None
 
 
 class IsDisambigPage(Exception):
@@ -51,7 +52,7 @@ def create_done_func(entitytype):
     `const.GENERIC_DONE_QUERY`.
     """
     query = const.GENERIC_DONE_QUERY.format(etype=entitytype)
-    func = lambda mbid: readonly_db.cursor().execute(query, {'mbid': mbid})
+    func = lambda mbid: readwrite_db.cursor().execute(query, {'mbid': mbid})
     return func
 
 
@@ -66,13 +67,16 @@ def setup_db():
     global readonly_db
     readonly_db = pg.connect(settings.readonly_connection_string)
     readonly_db.autocommit = True
+    global readwrite_db
+    readwrite_db = pg.connect(settings.readonly_connection_string)
+    readwrite_db.autocommit = True
 
 
 def create_table(query):
-    cur = readonly_db.cursor()
+    cur = readwrite_db.cursor()
     cur.execute("SET search_path TO musicbrainz")
     cur.execute(query)
-    readonly_db.commit()
+    readwrite_db.commit()
 
 
 def get_entities_with_wikilinks(query, limit):

--- a/bot/common.py
+++ b/bot/common.py
@@ -18,7 +18,7 @@ from urlparse import urlparse
 WIKI_PREFIX = "/wiki/"
 
 
-db = None
+readonly_db = None
 
 
 class IsDisambigPage(Exception):
@@ -51,7 +51,7 @@ def create_done_func(entitytype):
     `const.GENERIC_DONE_QUERY`.
     """
     query = const.GENERIC_DONE_QUERY.format(etype=entitytype)
-    func = lambda mbid: db.cursor().execute(query, {'mbid': mbid})
+    func = lambda mbid: readonly_db.cursor().execute(query, {'mbid': mbid})
     return func
 
 
@@ -63,20 +63,20 @@ def create_processed_table_query(entitytype):
 
 
 def setup_db():
-    global db
-    db = pg.connect(settings.connection_string)
-    db.autocommit = True
+    global readonly_db
+    readonly_db = pg.connect(settings.readonly_connection_string)
+    readonly_db.autocommit = True
 
 
 def create_table(query):
-    cur = db.cursor()
+    cur = readonly_db.cursor()
     cur.execute("SET search_path TO musicbrainz")
     cur.execute(query)
-    db.commit()
+    readonly_db.commit()
 
 
 def get_entities_with_wikilinks(query, limit):
-    cur = db.cursor()
+    cur = readonly_db.cursor()
     cur.execute(query, (limit,))
     return cur
 

--- a/bot/common.py
+++ b/bot/common.py
@@ -82,7 +82,6 @@ def setup_db():
 
 def create_table(query):
     cur = readwrite_db.cursor()
-    cur.execute("SET search_path TO musicbrainz")
     cur.execute(query)
     readwrite_db.commit()
 

--- a/bot/const.py
+++ b/bot/const.py
@@ -50,16 +50,12 @@ GENERIC_URL_MBID_QUERY =\
         ON entity0={etype}.id
     JOIN url
         ON l_{etype}_url.entity1=url.id
-    LEFT JOIN bot_wikidata_{etype}_processed AS bwep
-        ON {etype}.gid=bwep.gid
     WHERE
         lt.id IN ({wikipedia_linkid}, {wikidata_linkid})
     AND
         l_{etype}_url.edits_pending=0
     AND
         url.edits_pending=0
-    AND
-        bwep.gid is NULL
     LIMIT %s;
     """
 
@@ -97,16 +93,12 @@ QUERIES = defaultdict(lambda: None,
             ON entity1=w.id
         JOIN url
             ON lwu.entity0=url.id
-        LEFT JOIN bot_wikidata_work_processed AS bwwp
-            ON w.gid=bwwp.gid
         WHERE
             lt.id IN (279, 351)
         AND
             lwu.edits_pending=0
         AND
             url.edits_pending=0
-        AND
-            bwwp.gid is NULL
         LIMIT %s;
 
         """,
@@ -152,8 +144,6 @@ QUERIES = defaultdict(lambda: None,
             ON entity0=area.id
         JOIN url
             ON l_area_url.entity1=url.id
-        LEFT JOIN bot_wikidata_area_processed AS bwap
-            ON area.gid=bwap.gid
         WHERE
             lt.id IN (355, 358)
         AND

--- a/bot/const.py
+++ b/bot/const.py
@@ -59,6 +59,12 @@ GENERIC_URL_MBID_QUERY =\
     LIMIT %s;
     """
 
+GENERIC_ALREADY_PROCESSED_QUERY =\
+    """
+    SELECT gid
+    FROM bot_wikidata_{etype}_processed;
+    """
+
 GENERIC_DONE_QUERY =\
     """
     INSERT INTO bot_wikidata_{etype}_processed (GID)

--- a/bot/settings.py.dist
+++ b/bot/settings.py.dist
@@ -2,3 +2,4 @@ readonly_connection_string="dbname=musicbrainz user=musicbrainz"
 readwrite_connection_string="dbname=musicbrainz user=musicbrainz"
 mb_user=None
 mb_password=None
+sleep_time_in_seconds = 3600

--- a/bot/settings.py.dist
+++ b/bot/settings.py.dist
@@ -1,3 +1,4 @@
 readonly_connection_string="dbname=musicbrainz user=musicbrainz"
+readwrite_connection_string="dbname=musicbrainz user=musicbrainz"
 mb_user=None
 mb_password=None

--- a/bot/settings.py.dist
+++ b/bot/settings.py.dist
@@ -1,5 +1,8 @@
 readonly_connection_string="dbname=musicbrainz user=musicbrainz"
 readwrite_connection_string="dbname=musicbrainz user=musicbrainz"
+sleep_time_in_seconds = 3600
+
+# mb_user and mb_password are only required if the bot should fix links to
+# redirect pages in MusicBrainz. If that is not desired, leave them as `None`.
 mb_user=None
 mb_password=None
-sleep_time_in_seconds = 3600

--- a/bot/settings.py.dist
+++ b/bot/settings.py.dist
@@ -1,3 +1,3 @@
-connection_string="dbname=musicbrainz user=musicbrainz"
+readonly_connection_string="dbname=musicbrainz user=musicbrainz"
 mb_user=None
 mb_password=None


### PR DESCRIPTION
This changes the code so it uses a read-only connection for retrieving MBID <-> wikipedia link mappings from the database and a separate read-write connection for reading the tables that contain all the already processed MBIDs.

It also changes the code to reload the settings upon receiving a HUP signal, which recreates the db connections.

Things that are unclear to me right now:

* what happens if the HUP signal handler is called while a query is running?
* should the db connections maybe be created at the beginning of entity_type_loop instead of being kept open all the time?