### PR TITLE
Retry setting up connections after SIGHUP a few times

### DIFF
--- a/bot/common.py
+++ b/bot/common.py
@@ -28,14 +28,8 @@ from urlparse import urlparse
 # Set up a signal handler to reload the settings on SIGHUP
 def signal_handler(signal, frame):
     wp.output("HUP received")
-    wp.output("Old RO connection: {}".format(settings.readonly_connection_string))
-    wp.output("Old RW connection: {}".format(settings.readwrite_connection_string))
-    wp.output("Old mb_user {}".format(repr(settings.mb_user)))
-    reload(settings)
-    wp.output("New RO connection: {}".format(settings.readonly_connection_string))
-    wp.output("New RW connection: {}".format(settings.readwrite_connection_string))
-    wp.output("New mb_user {}".format(repr(settings.mb_user)))
-    setup_db()
+    reload_settings()
+    raise SettingsReloadedException("Settings have been reloaded during HUP")
 
 
 signal.signal(signal.SIGHUP, signal_handler)
@@ -59,6 +53,12 @@ class IsRedirectPage(Exception):
 
     def __str__(self):
         return "%s is a redirect to %s" % (self.old, self.new)
+
+
+class SettingsReloadedException(Exception):
+    """Custom Exception class to signal that the settings have been reloaded
+    during SIGHUP processing."""
+    pass
 
 
 def create_url_mbid_query(entitytype, linkids):
@@ -95,6 +95,16 @@ def create_processed_table_query(entitytype):
     `const.GENERIC_CREATE_PROCESSED_TABLE_QUERY`.
     """
     return const.GENERIC_CREATE_PROCESSED_TABLE_QUERY.format(etype=entitytype)
+
+
+def reload_settings():
+    wp.output("Old RO connection: {}".format(settings.readonly_connection_string))
+    wp.output("Old RW connection: {}".format(settings.readwrite_connection_string))
+    wp.output("Old mb_user {}".format(repr(settings.mb_user)))
+    reload(settings)
+    wp.output("New RO connection: {}".format(settings.readonly_connection_string))
+    wp.output("New RW connection: {}".format(settings.readwrite_connection_string))
+    wp.output("New mb_user {}".format(repr(settings.mb_user)))
 
 
 def setup_db():

--- a/run.py
+++ b/run.py
@@ -11,5 +11,22 @@ Command line options:
           added to their Wikidata pages. Example: `-entities:artist,work,place`
 -limit:x: Only handle x entities of *each* type
 """
-from bot.common import mainloop
-mainloop()
+import psycopg2
+import pywikibot as wp
+
+
+from bot.common import mainloop, SettingsReloadedException
+from time import sleep
+
+while True:
+    try:
+        mainloop()
+    except psycopg2.Error as e:
+        # It might take a few seconds for everything to properly work after
+        # settings have been changed, so give Docker a few seconds to get
+        # everything running.
+        wp.output("Trouble connecting to PostgreSQL: {}".format(e.pgerror))
+        sleep(5)
+    except SettingsReloadedException:
+        # Settings have been reloaded, just start the mainloop again.
+        pass


### PR DESCRIPTION
It might take a bit for configuration values etc. to be updated everywhere, so
just give it a few seconds.

Use a custom exception class to stop the world after reloading settings during
SIGHUP and just start the mainloop again.

This also moves complicated logic out of the signal handler into its own
reload_settings function that's called in the signal handler and at the
beginning of mainloop(). This allows moving the retry-on-pg-error logic into
run.py

Note: this hasn't been tested because I don't have an MB database at the moment :(