### PR TITLE
Check for 'instance of' 'disambiguation page' on wikidata

### DIFF
--- a/bot/const.py
+++ b/bot/const.py
@@ -11,6 +11,11 @@ WIKIDATA_DATASITE = WIKIDATA.data_repository()
 LinkIDsTuple = namedtuple("LinkIDs", "wikipedia wikidata")
 
 
+# The property id and item id for "is a disambiguation page" claims
+PROPERTY_ID_INSTANCE_OF = u"P31"
+ITEM_ID_DISAMBIGUATION_PAGE = "Q4167410"
+
+
 PROPERTY_IDS = {
     "area": "P982",
     "artist": "P434",


### PR DESCRIPTION
page.isDisambig() is False for wikidata items, even if they're instances
of a disambiguation page, so check for that manually.

https://www.wikidata.org/wiki/Q4500439 should never have been assigned an MBID, but has been. This prevents that.

This has been tested with the following:

```python
from bot import common
# Doesn't raise
common.get_wikidata_itempage_from_wikilink("https://www.wikidata.org/wiki/Q42")
# Doesn't raise
common.get_wikidata_itempage_from_wikilink("https://en.wikipedia.org/wiki/Douglas_Adams")
# Raises
common.get_wikidata_itempage_from_wikilink("https://www.wikidata.org/wiki/Q4500439")
# Raises
common.get_wikidata_itempage_from_wikilink("https://en.wikipedia.org/wiki/Khotkovo")
```