### PR TITLE
Cleanup work

### DIFF
--- a/bot/common.py
+++ b/bot/common.py
@@ -323,7 +323,7 @@ def entity_type_loop(bot, entitytype, limit):
         results_to_process = [r for r in all_results if r[0] not in
                               already_processed_results]
 
-    if len(results_to_process) == 0:
+    if not results_to_process:
         wp.output("No more unprocessed entries in MB")
 
     map(bot.process_result, results_to_process)

--- a/bot/common.py
+++ b/bot/common.py
@@ -115,14 +115,14 @@ def setup_db():
     if readonly_db is not None:
         readonly_db.close()
     readonly_db = pg.connect(settings.readonly_connection_string,
-                             application_name="mb2wikidatabot readonly")
+                             application_name="mb2wikidatabot_readonly")
     readonly_db.autocommit = True
 
     global readwrite_db
     if readwrite_db is not None:
         readwrite_db.close()
     readwrite_db = pg.connect(settings.readwrite_connection_string,
-                              application_name="mb2wikidatabot readwrite")
+                              application_name="mb2wikidatabot_readwrite")
     readwrite_db.autocommit = True
 
 

--- a/bot/common.py
+++ b/bot/common.py
@@ -114,13 +114,15 @@ def setup_db():
     global readonly_db
     if readonly_db is not None:
         readonly_db.close()
-    readonly_db = pg.connect(settings.readonly_connection_string)
+    readonly_db = pg.connect(settings.readonly_connection_string,
+                             application_name="mb2wikidatabot readonly")
     readonly_db.autocommit = True
 
     global readwrite_db
     if readwrite_db is not None:
         readwrite_db.close()
-    readwrite_db = pg.connect(settings.readwrite_connection_string)
+    readwrite_db = pg.connect(settings.readwrite_connection_string,
+                              application_name="mb2wikidatabot readwrite")
     readwrite_db.autocommit = True
 
 

--- a/bot/common.py
+++ b/bot/common.py
@@ -313,13 +313,13 @@ def entity_type_loop(bot, entitytype, limit):
     linkids = const.LINK_IDS[entitytype]
 
     wiki_entity_query = create_url_mbid_query(entitytype, linkids)
-    all_results = do_readonly_query(wiki_entity_query, limit)
     already_processed_query = create_already_processed_query(entitytype)
-    already_processed_results = frozenset(
-           do_readwrite_query(already_processed_query))
 
-    results_to_process = [r for r in all_results if r[0] not in
-                          already_processed_results]
+    with do_readonly_query(wiki_entity_query, limit) as all_results, do_readwrite_query(already_processed_query) as already_processed:
+        already_processed_results = frozenset(already_processed)
+
+        results_to_process = [r for r in all_results if r[0] not in
+                              already_processed_results]
 
     if len(results_to_process) == 0:
         wp.output("No more unprocessed entries in MB")

--- a/bot/const.py
+++ b/bot/const.py
@@ -115,36 +115,6 @@ QUERIES = defaultdict(lambda: None,
         """,
         'area':
         """
-        WITH valid_areas AS (
-            SELECT area
-            FROM place
-            UNION
-            SELECT area
-            FROM label
-            UNION
-            SELECT area
-            FROM artist
-            UNION
-            SELECT begin_area
-            FROM artist
-            UNION
-            SELECT end_area
-            FROM artist
-            UNION
-            SELECT area
-            FROM country_area
-            JOIN release_country
-            ON release_country.country = country_area.area
-            UNION
-            SELECT entity0
-            FROM l_area_recording
-            UNION
-            SELECT entity0
-            FROM l_area_release
-            UNION
-            SELECT entity0
-            FROM l_area_work
-            )
         SELECT area.gid, url.gid, url.url
         FROM l_area_url
         JOIN link AS l
@@ -162,7 +132,36 @@ QUERIES = defaultdict(lambda: None,
         AND
             url.edits_pending=0
         AND
-            area.id IN (SELECT area FROM valid_areas)
+        area.id IN (
+            SELECT area
+            FROM place
+            UNION ALL
+            SELECT area
+            FROM label
+            UNION ALL
+            SELECT area
+            FROM artist
+            UNION ALL
+            SELECT begin_area
+            FROM artist
+            UNION ALL
+            SELECT end_area
+            FROM artist
+            UNION ALL
+            SELECT area
+            FROM country_area
+                JOIN release_country
+                ON release_country.country = country_area.area
+            UNION ALL
+            SELECT entity0
+            FROM l_area_recording
+            UNION ALL
+            SELECT entity0
+            FROM l_area_release
+            UNION ALL
+            SELECT entity0
+            FROM l_area_work
+        )
         LIMIT %s;
         """
     }


### PR DESCRIPTION
The first commit makes the area query a bit faster. @samj1912 ran this on the MeB infrastructure and the execution time went from ~4 seconds to 1-2.

The second commit closes the cursors doing somewhat large selects immediately after using them.

The third commit just makes sure an application name is passed to PG, so spotting the connections of the bot in pg_stat_activity and others is easier.