### PR TITLE
Don't raise exception when getting Item pages that are redirects

### DIFF
--- a/bot/common.py
+++ b/bot/common.py
@@ -182,7 +182,7 @@ def get_wikidata_itempage_from_wikilink(wikilink):
     else:
         raise ValueError("%s is not a link to a wikipedia page" % wikilink)
     try:
-        wikidatapage.get()
+        wikidatapage.get(get_redirect=True)
     except wp.data.api.APIError:
         wp.output("%s does not exist" % pagename)
         return None


### PR DESCRIPTION
This fixes the following exception:

> Traceback (most recent call last):
>   File "/code/run.py", line 24, in <module>
>     mainloop()
>   File "/code/bot/common.py", line 354, in mainloop
>     entity_type_loop(bot, entitytype, limit)
>   File "/code/bot/common.py", line 329, in entity_type_loop
>     map(bot.process_result, results_to_process)
>   File "/code/bot/common.py", line 272, in process_result
>     itempage = get_wikidata_itempage_from_wikilink(wikipage)
>   File "/code/bot/common.py", line 185, in get_wikidata_itempage_from_wikilink
>     wikidatapage.get()
>   File "/usr/local/lib/python2.7/site-packages/pywikibot-3.0.20181003.dev0-py2.7.egg/pywikibot/page.py", line 4452, in get
>     raise pywikibot.IsRedirectPage(self)
> IsRedirectPage: Page [[wikidata:Q14209321]] is a redirect page.

Since
https://github.com/wikimedia/pywikibot/commit/31fbc0790674ef333dda743ba1de3ff1d6abfa97 (Support
item redirects in get method in ItemPage), this exception can be disabled by
setting `get_redirect=True` in the call of `.get()`.

The log from the currently running bot is full of

```
[...]
» https://www.wikidata.org/wiki/Q14209321 https://musicbrainz.org/area/cd316c35-768b-4c0d-afe9-bf9f84e4ad74
Traceback (most recent call last):
  File "/code/run.py", line 24, in <module>
    mainloop()
  File "/code/bot/common.py", line 354, in mainloop
    entity_type_loop(bot, entitytype, limit)
  File "/code/bot/common.py", line 329, in entity_type_loop
    map(bot.process_result, results_to_process)
  File "/code/bot/common.py", line 272, in process_result
    itempage = get_wikidata_itempage_from_wikilink(wikipage)
  File "/code/bot/common.py", line 185, in get_wikidata_itempage_from_wikilink
    wikidatapage.get()
  File "/usr/local/lib/python2.7/site-packages/pywikibot-3.0.20181003.dev0-py2.7.egg/pywikibot/page.py", line 4452, in get
    raise pywikibot.IsRedirectPage(self)
IsRedirectPage: Page [[wikidata:Q14209321]] is a redirect page.
» https://en.wikipedia.org/wiki/Minato-ku,_Osaka https://musicbrainz.org/area/90b4b6ef-d921-4eba-9256-309a402a0bd5
https://en.wikipedia.org/wiki/Minato-ku,_Osaka already has property P982 with value 90b4b6ef-d921-4eba-9256-309a402a0bd5
[...]
```

repeated over and over again. The pattern is clear: once `IsRedirectPage` is raised, the bot starts to process all areas from the beginning again. 

For some reason, it always begins at the same area (Minato-ku,_Osaka) again, although I would have expected that to be written to the db as already processed. I do not yet understand why that is not the case.

This pull request should at least move us across the point of the IsRedirectPage exception.