### PR TITLE
Extract UUIDs into already_processed_results 

### DIFF
--- a/bot/common.py
+++ b/bot/common.py
@@ -318,7 +318,7 @@ def entity_type_loop(bot, entitytype, limit):
     already_processed_query = create_already_processed_query(entitytype)
 
     with do_readonly_query(wiki_entity_query, limit) as all_results, do_readwrite_query(already_processed_query) as already_processed:
-        already_processed_results = frozenset(already_processed)
+        already_processed_results = frozenset((row[0] for row in already_processed))
         all_results_list = list(all_results)
 
         if already_processed_results:

--- a/bot/common.py
+++ b/bot/common.py
@@ -88,7 +88,6 @@ def create_done_func(entitytype):
     query = const.GENERIC_DONE_QUERY.format(etype=entitytype)
 
     def func(mbid):
-        wp.output("Executing '{query}' with mbid='{mbid}'".format(query=query, mbid=mbid))
         do_readwrite_query(query, {'mbid': mbid})
 
     return func


### PR DESCRIPTION
Later on, already_processed_results is used to check if it already contains
specific UUIDs. For that to work, it obviously needs to contain only UUIDs, not
just rows/tuples.

Let's leave the debug statements in for now to see if all types are as expected now.