### PR TITLE
Reduce the log output of the bot

### DIFF
--- a/bot/common.py
+++ b/bot/common.py
@@ -319,16 +319,8 @@ def entity_type_loop(bot, entitytype, limit):
 
     with do_readonly_query(wiki_entity_query, limit) as all_results, do_readwrite_query(already_processed_query) as already_processed:
         already_processed_results = frozenset((row[0] for row in already_processed))
-        all_results_list = list(all_results)
 
-        if already_processed_results:
-            elem = list(already_processed_results)[0]
-            wp.output("Type of already_processed_results: {}".format(type(elem)))
-        if all_results:
-            elem = all_results_list[0][0]
-            wp.output("Type of all_results: {}".format(type(elem)))
-
-        results_to_process = [r for r in all_results_list if r[0] not in
+        results_to_process = [r for r in all_results if r[0] not in
                               already_processed_results]
 
     if not results_to_process:


### PR DESCRIPTION
This changes all output during normal operation to log level DEBUG. This reduces the per-entity messages to zero. Error messages  contain enough information to still allow investigating problems. An additional message is added when switching from one entity type to another
with the amount of entities of that type that are going to be processed, to give
a rough estimate of how long things should take (hours? days? weeks?).

This also changes errors and warnings to log
levels ERROR/WARN. These are either errors from the pywikibot framework or messages that require human interaction to fix (like links to wikidata items that don't exist).