### PR TITLE
Do not add MBIDs for works to wikidata items

### DIFF
--- a/bot/const.py
+++ b/bot/const.py
@@ -24,7 +24,7 @@ PROPERTY_IDS = {
     "place": "P1004",
     "release_group": "P436",
     "series": "P1407",
-    "work": "P435",
+    # "work": "P435",
 }
 
 
@@ -36,7 +36,7 @@ LINK_IDS = {
     "place": LinkIDsTuple(595, 594),
     "release_group": LinkIDsTuple(89, 353),
     "series": LinkIDsTuple(744, 749),
-    "work": LinkIDsTuple(279, 351),
+    # "work": LinkIDsTuple(279, 351),
 }
 
 


### PR DESCRIPTION
See the constraints on https://www.wikidata.org/wiki/Property:P435 and the
discussion at https://www.wikidata.org/wiki/Topic:Uxsiyqueknvmvfsm (but also
https://www.wikidata.org/wiki/Property_talk:P435, which lists singles as the
domain for P435). Just disable works until the Wikidata people get their act
together.

CC @reosarevok 