### PR TITLE
Rate limit

### DIFF
--- a/docker/settings.py.ctmpl
+++ b/docker/settings.py.ctmpl
@@ -11,7 +11,10 @@ readwrite_connection_string="dbname=wikidata_bot_db user=musicbrainz host={{.Add
 
 # mb_user and mb_password are only required if the bot should fix links to
 # redirect pages in MusicBrainz. If that is not desired, leave them as `None`.
+# mb_editor_id is required for limiting the number of open edits. If it's not
+# supplied, editing is not possible
 mb_user="{{template "KEY" "mb_user"}}"
 mb_password="{{template "KEY" "mb_password"}}"
+mb_editor_id="{{ template "KEY" "mb_editor_id"}}"
 
 sleep_time_in_seconds = 3600


### PR DESCRIPTION
This updates the musicbrainz_bot submodule with the following changes: https://github.com/mineo/musicbrainz-bot/compare/cd4fb4dc7f777f16a48b343474ecadc2c8f4f670...38f2bd7f0a65f6c346e8604f1bc75980f438603e#diff-7877b0d45b9b8ba7e5b06ed50161656a to consider the limit of open edits, as well as the number of edits opened per day.

It uses that to skip fixing redirects (the only editing action on the MB side at the moment) if either of the limits is reached. After each round of processing all entity types, the rate limits are updated with data from MB. This is for the case where the bot runs across midnight.

Getting the rate limit data from MB performs a search for edits with the editor id. That is supplied via a new setting, `mb_editor_id`. The editor_id of Harry Botter is 1326016. If that is not set, editing will not be enabled.