### PR TITLE
Pin a specific version of the python base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM metabrainz/python:3.8
+FROM metabrainz/python:3.8-20191226
 
 ENV DOCKERIZE_VERSION v0.2.0
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \


### PR DESCRIPTION
In https://github.com/metabrainz/docker-python/pull/9 we added the current date to the version tag of base images that we build. 

This change explicitly tags the old version of this base image so that it's not affected by newer images that we push. We recommend that downstream projects now use an explicit dated version to be certain that the correct base image is being used.